### PR TITLE
Add regex to improve validation for the isoDateTime codec

### DIFF
--- a/packages/codec/src/testUtil.ts
+++ b/packages/codec/src/testUtil.ts
@@ -82,6 +82,9 @@ export function verifyExpectation(
     expect(result.errors.map(({ path, message }) => [path.join('.'), message])).toEqual(
       expectation.errors
     )
+  } else if (expectation.success && !result.success) {
+    expect(result.errors).toBe([])
+    expect(result.success).toEqual(expectation.success)
   } else {
     expect(result.success).toEqual(expectation.success)
   }

--- a/packages/codec/src/types/isoDate.spec.ts
+++ b/packages/codec/src/types/isoDate.spec.ts
@@ -28,6 +28,10 @@ describe('ISO Date Codec', () => {
     decodeFailureExpectation('not parse date with time', codec, '1990-10-10T12:10:10.000Z', [
       '',
       'must be a valid date'
+    ]),
+    decodeFailureExpectation('not parse date that does not match the regex', codec, '0', [
+      '',
+      'must be a valid date'
     ])
   ])
 })

--- a/packages/codec/src/types/isoDateTime.spec.ts
+++ b/packages/codec/src/types/isoDateTime.spec.ts
@@ -1,0 +1,45 @@
+import {
+  decodeFailureExpectation,
+  decodeSuccessExpectation,
+  encodeExpectation,
+  executeDecodeTests,
+  executeEncodeTests
+} from '../testUtil'
+
+import { IsoDateTimeCodec } from './isoDateTime'
+
+describe('ISO DateTime Codec', () => {
+  const codec = new IsoDateTimeCodec()
+  const date = new Date('1990-10-10T13:37:59.123Z')
+
+  executeEncodeTests([
+    encodeExpectation('encode simple datetime', codec, date, '1990-10-10T13:37:59.123Z')
+  ])
+
+  executeDecodeTests([
+    decodeSuccessExpectation(
+      'parse valid datetime',
+      codec,
+      '1990-10-10T01:23:00.000Z',
+      new Date('1990-10-10T01:23:00.000Z')
+    ),
+    decodeSuccessExpectation(
+      'parse valid datetime without milliseconds',
+      codec,
+      '1990-10-10T01:23:00Z',
+      new Date('1990-10-10T01:23:00.000Z')
+    ),
+    decodeFailureExpectation('not parse date only', codec, '1990-10-10', [
+      '',
+      'must be a valid ISO datetime'
+    ]),
+    decodeFailureExpectation('not parse invalid date', codec, 'hello', [
+      '',
+      'must be a valid ISO datetime'
+    ]),
+    decodeFailureExpectation('not parse date that does not match the regex', codec, '0', [
+      '',
+      'must be a valid ISO datetime'
+    ])
+  ])
+})

--- a/packages/codec/src/types/isoDateTime.ts
+++ b/packages/codec/src/types/isoDateTime.ts
@@ -5,6 +5,8 @@ import { BaseCodec, CodecOptions } from '.'
 
 export class IsoDateTimeCodec extends BaseCodec<Date, string> {
   readonly _tag = 'IsoDateTimeCodec' as const
+  // JS Date object does not handle leap seconds, so no need to expect 60 in the seconds field.
+  private readonly pattern = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-2][0-9]:[0-5][0-9]:[0-5][0-9](.[0-9]{3})?Z?$/
 
   protected doIs(value: unknown): value is Date {
     return value instanceof Date
@@ -15,13 +17,13 @@ export class IsoDateTimeCodec extends BaseCodec<Date, string> {
   }
 
   protected doDecode(value: unknown, context: Context): Validation<Date> {
-    if (typeof value !== 'string') {
-      return failure(context, value, 'must be a valid timestamp')
+    if (typeof value !== 'string' || !this.pattern.test(value)) {
+      return failure(context, value, 'must be a valid ISO datetime')
     }
 
     const parsed = new Date(value)
     if (isNaN(parsed.getTime())) {
-      return failure(context, value, 'must be a valid timestamp')
+      return failure(context, value, 'must be a valid ISO datetime')
     }
 
     return success(parsed)


### PR DESCRIPTION
Add regex to improve validation for the isoDateTime codec

We have noticed that passing '0' as a datetime results in it being parsed as a unix timestamp, giving a datetime of 2000-01-01T00:00:00Z. This is almost certainly unintentional and we should be more defensive.

- Add a regex that only allows YYYY-dd-mmTHH:MM:SS with optional milliseconds and optional 'Z' timezone specifier.
- Add tests for isoDateTime codec.

### Bonus fix:

[testUtils] Improve output when expected success is a failure

When we are expecting the result to be successful but it isn't, we were only getting output that success != true, which doesn't tell you much - it's better to see the errors (that shouldn't be happening).

In this case (expecting success but actually it's a failure), we can assert that the errors should be empty and that will cause the errors to print out first, which is more useful for debugging.
