### PR TITLE
Make 'yarn test' work in root directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typescript": "^4.2.4"
   },
   "scripts": {
-    "test": "jest --config jest.config.js --maxWorkers 1",
+    "test": "lerna run test",
     "execute": "-r ts-node/register -r tsconfig-paths/register"
   },
   "dependencies": {

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
-    "test": "jest"
+    "test": "jest --passWithNoTests"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
-    "test": "jest"
+    "test": "jest --passWithNoTests"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
-    "test": "jest --config ../../jest.config.js"
+    "test": "jest --passWithNoTests"
   },
   "devDependencies": {
     "@nestjs/common": "^7.6.15",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
-    "test": "jest --config ../../jest.config.js",
+    "test": "jest --passWithNoTests",
     "execute": "node -r ts-node/register -r tsconfig-paths/register"
   },
   "publishConfig": {


### PR DESCRIPTION
Make running tests more intuitive with `yarn test` in the root directory, by leveraging `lerna run`, which will run the yarn script in each package.

- Update root package.json to run `lerna run test`
- Allow the packages without tests to not fail.
