### PR TITLE
Allow booleans to be lenient

### DIFF
--- a/packages/codec/src/types/boolean.spec.ts
+++ b/packages/codec/src/types/boolean.spec.ts
@@ -7,6 +7,18 @@ describe('Boolean Codec', () => {
 
   executeDecodeTests([
     decodeSuccessExpectation('parse simple boolean', codec, true, true),
+    decodeSuccessExpectation('parse lenient string', codec.lenient(), 'true', true),
+    decodeSuccessExpectation('parse lenient string', codec.lenient(), 'false', false),
+    decodeSuccessExpectation('parse lenient string', codec.lenient(), 'TRUE', true),
+    decodeSuccessExpectation('parse lenient string', codec.lenient(), 'FALSE', false),
+    decodeFailureExpectation('not parse lenient string when invalid', codec.lenient(), '1', [
+      '',
+      'must be a boolean'
+    ]),
+    decodeFailureExpectation('not parse lenient string when invalid', codec.lenient(), '0', [
+      '',
+      'must be a boolean'
+    ]),
     decodeFailureExpectation('not parse strings', codec, 'test', ['', 'must be a boolean']),
     decodeFailureExpectation('not parse numbers', codec, 123, ['', 'must be a boolean'])
   ])

--- a/packages/codec/src/types/boolean.spec.ts
+++ b/packages/codec/src/types/boolean.spec.ts
@@ -7,10 +7,14 @@ describe('Boolean Codec', () => {
 
   executeDecodeTests([
     decodeSuccessExpectation('parse simple boolean', codec, true, true),
-    decodeSuccessExpectation('parse lenient string', codec.lenient(), 'true', true),
-    decodeSuccessExpectation('parse lenient string', codec.lenient(), 'false', false),
-    decodeSuccessExpectation('parse lenient string', codec.lenient(), 'TRUE', true),
-    decodeSuccessExpectation('parse lenient string', codec.lenient(), 'FALSE', false),
+    decodeSuccessExpectation('parse lenient string true', codec.lenient(), 'true', true),
+    decodeSuccessExpectation('parse lenient string false', codec.lenient(), 'false', false),
+    decodeSuccessExpectation('parse lenient string TRUE', codec.lenient(), 'TRUE', true),
+    decodeSuccessExpectation('parse lenient string FALSE', codec.lenient(), 'FALSE', false),
+    decodeFailureExpectation('not parse string when not in lenient mode', codec, 'true', [
+      '',
+      'must be a boolean'
+    ]),
     decodeFailureExpectation('not parse lenient string when invalid', codec.lenient(), '1', [
       '',
       'must be a boolean'

--- a/packages/codec/src/types/boolean.ts
+++ b/packages/codec/src/types/boolean.ts
@@ -5,7 +5,6 @@ import { BaseCodec, CodecOptions } from './'
 
 export class BooleanCodec extends BaseCodec<boolean> {
   readonly _tag = 'BooleanCodec' as const
-  static readonly possibleValues = ['true', 'false']
 
   constructor(public readonly isLenient: boolean = false, options: CodecOptions<boolean> = {}) {
     super(options)

--- a/packages/codec/src/types/boolean.ts
+++ b/packages/codec/src/types/boolean.ts
@@ -5,6 +5,11 @@ import { BaseCodec, CodecOptions } from './'
 
 export class BooleanCodec extends BaseCodec<boolean> {
   readonly _tag = 'BooleanCodec' as const
+  static readonly possibleValues = ['true', 'false']
+
+  constructor(public readonly isLenient: boolean = false, options: CodecOptions<boolean> = {}) {
+    super(options)
+  }
 
   protected doIs(value: unknown): value is boolean {
     return typeof value === 'boolean'
@@ -15,14 +20,25 @@ export class BooleanCodec extends BaseCodec<boolean> {
   }
 
   protected doDecode(value: unknown, context: Context): Validation<boolean> {
-    if (typeof value !== 'boolean') {
-      return failure(context, value, 'must be a boolean')
+    if (typeof value === 'boolean') {
+      return success(value)
+    } else if (typeof value === 'string') {
+      const lowerValue = value.toLowerCase()
+      if (lowerValue === 'true') {
+        return success(true)
+      } else if (lowerValue === 'false') {
+        return success(false)
+      }
     }
 
-    return success(value)
+    return failure(context, value, 'must be a boolean')
   }
 
   protected with(options: CodecOptions<boolean>): BaseCodec<boolean> {
-    return new BooleanCodec(options)
+    return new BooleanCodec(this.isLenient, options)
+  }
+
+  public lenient(): BooleanCodec {
+    return new BooleanCodec(true, this.options)
   }
 }

--- a/packages/codec/src/types/boolean.ts
+++ b/packages/codec/src/types/boolean.ts
@@ -22,7 +22,7 @@ export class BooleanCodec extends BaseCodec<boolean> {
   protected doDecode(value: unknown, context: Context): Validation<boolean> {
     if (typeof value === 'boolean') {
       return success(value)
-    } else if (typeof value === 'string') {
+    } else if (typeof value === 'string' && this.isLenient) {
       const lowerValue = value.toLowerCase()
       if (lowerValue === 'true') {
         return success(true)

--- a/packages/codec/src/types/number.ts
+++ b/packages/codec/src/types/number.ts
@@ -40,7 +40,7 @@ export class NumberCodec extends BaseCodec<number> {
   }
 
   public lenient(): NumberCodec {
-    return new NumberCodec(true)
+    return new NumberCodec(true, this.options)
   }
 
   public integer(message?: string): NumberCodec {


### PR DESCRIPTION
This PR adds support for lenient booleans that accept `true` or `false` as strings (such as in query parameters) to be converted into booleans. Note that this _only_ allows exactly `true` or `false` - regardless of case. No other boolean-coercible values, such as 1 and 0, are allowed.