### PR TITLE
Remove interceptor registration

### DIFF
--- a/packages/nestjs/src/index.ts
+++ b/packages/nestjs/src/index.ts
@@ -1,5 +1,6 @@
 export * from './salus-module'
 export * from './operation-registry'
 export * from './decorators'
+export * from './serialization-interceptor'
 export * from './types'
 export * from './utils'

--- a/packages/nestjs/src/salus-module.ts
+++ b/packages/nestjs/src/salus-module.ts
@@ -8,14 +8,13 @@ import {
   RequestMethod,
   Type
 } from '@nestjs/common'
-import { APP_INTERCEPTOR, ModuleRef } from '@nestjs/core'
+import { ModuleRef } from '@nestjs/core'
 import { Operation } from '@salus-js/http'
 import { OpenAPIOptions, toOpenApi } from '@salus-js/openapi'
 import type { Request, Response } from 'express'
 
 import { MODULE_OPTIONS_TOKEN } from './constants'
 import { OperationRegistry } from './operation-registry'
-import { SerializationInterceptor } from './serialization-interceptor'
 
 export interface SalusModuleOptions {
   /**

--- a/packages/nestjs/src/salus-module.ts
+++ b/packages/nestjs/src/salus-module.ts
@@ -48,11 +48,6 @@ export interface SalusModuleOptionsFactory {
 @Module({
   providers: [
     {
-      provide: APP_INTERCEPTOR,
-      inject: [MODULE_OPTIONS_TOKEN],
-      useFactory: () => new SerializationInterceptor()
-    },
-    {
       provide: OperationRegistry,
       inject: [ModuleRef],
       useFactory: (module) => OperationRegistry.from(module)


### PR DESCRIPTION
As Nest does not allow you to configure the ordering of interceptors pulled in from other modules we will export the SerializationInterceptor for manual registration instead of registering it as a provider of the slaus nest module