### PR TITLE
Adds new documentation capabilities

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,10 @@ const path = require('path') // eslint-disable-line
 module.exports.commonJestConfig = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  setupFilesAfterEnv: [path.join(__dirname, 'jest', 'jest-env.ts')]
+  setupFilesAfterEnv: [path.join(__dirname, 'jest', 'jest-env.ts')],
+  moduleNameMapper: {
+    "@salus-js/(.*)": [
+      "<rootDir>/../../packages/$1/src/index.ts"
+    ]
+  }
 }

--- a/packages/codec/src/types/base.ts
+++ b/packages/codec/src/types/base.ts
@@ -9,10 +9,13 @@ const emptyRefinements: Refinement<any, any>[] = []
 
 export interface CodecOptions<A> {
   /**
+   * Title to apply to this codec
+   */
+  readonly title?: string
+  /**
    * Description of the purpose of this codec
    */
   readonly description?: string
-
   /**
    * Exmaple of a typical value associated with this codec
    */
@@ -21,6 +24,10 @@ export interface CodecOptions<A> {
    * Array of all refinements to apply to the codec
    */
   readonly refinements?: Refinement<A, any>[]
+  /**
+   * Arbitrary additional data to attach to the codec
+   */
+  readonly extensions?: Record<string, unknown>
 }
 
 export abstract class BaseCodec<A, O = A> extends Codec<A, O> {
@@ -90,7 +97,9 @@ export abstract class BaseCodec<A, O = A> extends Codec<A, O> {
    * @param options the new options to attach to the codec
    * @returns a new codec with the attached options
    */
-  public document(options: Pick<CodecOptions<A>, 'description' | 'example'>): this {
+  public document(
+    options: Pick<CodecOptions<A>, 'title' | 'description' | 'example' | 'extensions'>
+  ): this {
     return this.with({
       ...this.options,
       ...options

--- a/packages/codec/src/types/concrete.ts
+++ b/packages/codec/src/types/concrete.ts
@@ -34,7 +34,9 @@ export class ConcreteCodec<A, O> extends Codec<A, O> {
     return new NullableCodec(this)
   }
 
-  public document(options: Pick<CodecOptions<A>, 'description' | 'example'>): ReferenceCodec<A, O> {
+  public document(
+    options: Pick<CodecOptions<A>, 'title' | 'description' | 'example' | 'extensions'>
+  ): ReferenceCodec<A, O> {
     return new ReferenceCodec(this, options)
   }
 

--- a/packages/http/src/operation.ts
+++ b/packages/http/src/operation.ts
@@ -45,6 +45,10 @@ export interface OperationOptions<
    * Codec for response payload
    */
   readonly response: TResponse
+  /**
+   * Arbitrary additional properties for the operation
+   */
+  readonly extensions?: Record<string, unknown>
 }
 
 export class Operation<

--- a/packages/openapi/jest.config.js
+++ b/packages/openapi/jest.config.js
@@ -1,0 +1,6 @@
+const { commonJestConfig } = require('../../jest.config') // eslint-disable-line
+
+module.exports = {
+  ...commonJestConfig,
+  testMatch: ['<rootDir>/src/**/*.spec.ts']
+}

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "lint": "eslint --ext .ts,.js src",
     "execute": "node -r ts-node/register -r tsconfig-paths/register"
   },

--- a/packages/openapi/src/builder.ts
+++ b/packages/openapi/src/builder.ts
@@ -153,6 +153,12 @@ export function toOpenApi(providedOptions: OpenAPIOptions): OpenAPIObject {
 
     documentedOperation.responses = responseBodyFactory(operation, visitor)
 
+    if (operation.options.extensions) {
+      for (const [key, value] of Object.entries(operation.options.extensions)) {
+        documentedOperation[`x-${key}`] = value
+      }
+    }
+
     const path = operation.formatPath(pathParameters)
     document.paths[path] ||= {}
     document.paths[path][operation.options.method] = documentedOperation

--- a/packages/openapi/src/visitor.spec.ts
+++ b/packages/openapi/src/visitor.spec.ts
@@ -1,0 +1,38 @@
+import { t } from '@salus-js/codec'
+
+import { NullableConverter } from './converters/nullable'
+import { ReferenceConverter } from './converters/reference'
+import { StringConverter } from './converters/string'
+import { SchemaVisitor } from './visitor'
+
+describe('SchemaVisitor', () => {
+  it('should mark wrapped codecs', () => {
+    const visitor = new SchemaVisitor({
+      converters: [StringConverter, ReferenceConverter]
+    })
+
+    const namedSchema = t.named('test', t.string)
+
+    const result = visitor.convert(
+      namedSchema.document({
+        description: 'This is a description'
+      })
+    )
+
+    expect(result).toHaveProperty('x-wrapped', true)
+  })
+
+  it('should support null examples', () => {
+    const visitor = new SchemaVisitor({
+      converters: [StringConverter, NullableConverter]
+    })
+
+    const result = visitor.convert(
+      t.string.nullable().document({
+        example: null
+      })
+    )
+
+    expect(result).toHaveProperty('example', null)
+  })
+})

--- a/packages/openapi/src/visitor.ts
+++ b/packages/openapi/src/visitor.ts
@@ -64,16 +64,26 @@ export class SchemaVisitor {
 
     if (codec instanceof BaseCodec) {
       const additionalProperties: SchemaObject = {}
+      if (codec.options.title) {
+        additionalProperties.title = codec.options.title
+      }
+
       if (codec.options.description) {
         additionalProperties.description = codec.options.description
       }
 
-      if (codec.options.example) {
-        additionalProperties.example = codec.options.example
+      if (typeof codec.options.example !== 'undefined') {
+        additionalProperties.example = codec.encode(codec.options.example)
+      }
+
+      if (codec.options.extensions) {
+        for (const [key, value] of Object.entries(codec.options.extensions)) {
+          additionalProperties[`x-${key}`] = value
+        }
       }
 
       if (Object.keys(additionalProperties).length > 0) {
-        schema = isReferenceObject(schema) ? { oneOf: [schema] } : schema
+        schema = isReferenceObject(schema) ? { oneOf: [schema], 'x-wrapped': true } : schema
         return {
           ...schema,
           ...additionalProperties


### PR DESCRIPTION
This PR adds a few new capabilities that we can use in documentation (and SDK) generation.

## Changes
- Adding a `title` property to schemas to coincide with the property of the same name in OpenAPI
- Extensions for codecs to allow adding arbitrary key/values to the OpenAPI spec (prefixed `x-` in the spec)
- Extensions for operations for the same
- A bugfix to how examples are applied to docs (a `null` was being interpreted as no example)
- Adding an `x-wrapped` property to schemas that are generated when a named schema is referenced and a description is applied (more below)

## X-Wrapped Property
Due to a limitation in OpenAPI 3.0 (OpenAPI 3.1 changes this but is not yet widely supported), we're unable to override a description on a reference property. Consider a schema such as:

```
member:
  type: object
  description: This is a member
  properties:
    name:
      type: string
device:
  type: object
  description: This is a device
  properties:
    member: 
      $ref: '#/components/schemas/member'
```

If we generate documentation for this schema, the `member` property will be documented as "This is a member." However, in many cases, we don't want to inherit documentation from the referenced schema. Instead, we'd like to provide documentation specific to what the `member` property means on a device in particular. Thee OpenAPI 3.0 spec does not allow us to add a `description` to a ReferenceSchema. Instead, we can work around this by using the following schema:

```
device:
  type: object
  description: This is a device
  properties:
    member: 
      oneOf:
        - $ref: '#/components/schemas/member'
      description: The member to which this device belongs
```

In other words, we wrap the reference in a union schema with one option. Now, our schema is no longer a reference schema, so we can apply a description to this. This is a sensible (and the recommended) workaround. However, in doing so, we create a new problem: there's no way to differentiate between a "transparent union with a description" and other types of unions. It would be possible to simply look for a union schema with `oneOf.length === 1`, but that may have other ramifications. Instead, this PR adds `x-wrapped` to the generated schema so that we know we can simply unwind the `oneOf`, access the first child schema to know what's going on.