### PR TITLE
Store file on the request body

### DIFF
--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -45,5 +45,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "9153d423f6d2416bbfb957f312379c2d9ad73547",
+  "gitHead": "9153d423f6d2416bbfb957f312379c2d9ad73547"
 }

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -28,7 +28,6 @@
     "@salus-js/codec": "^0.9.3",
     "@salus-js/http": "^0.9.3",
     "@salus-js/openapi": "^0.9.3",
-    "@types/express": "^4.17.11",
     "express": "^4",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^6.0.0"
@@ -39,6 +38,7 @@
     "@salus-js/codec": "*",
     "@salus-js/http": "*",
     "@salus-js/openapi": "*",
+    "@types/express": "^4.17.11",
     "rxjs": "*"
   },
   "publishConfig": {

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -28,7 +28,7 @@
     "@salus-js/codec": "^0.9.3",
     "@salus-js/http": "^0.9.3",
     "@salus-js/openapi": "^0.9.3",
-    "@types/express": "^4.17.11",
+    "@types/express": "^4.17.13",
     "@types/multer": "^1.4.7",
     "express": "^4",
     "reflect-metadata": "^0.1.13",

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -30,7 +30,6 @@
     "@salus-js/openapi": "^0.10.0",
     "@types/express": "^4.17.13",
     "@types/multer": "^1.4.7",
-    "@types/express": "^4.17.11",
     "express": "^4",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^6.0.0"

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -28,6 +28,8 @@
     "@salus-js/codec": "^0.9.3",
     "@salus-js/http": "^0.9.3",
     "@salus-js/openapi": "^0.9.3",
+    "@types/express": "^4.17.11",
+    "@types/multer": "^1.4.7",
     "express": "^4",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^6.0.0"
@@ -38,14 +40,10 @@
     "@salus-js/codec": "*",
     "@salus-js/http": "*",
     "@salus-js/openapi": "*",
-    "@types/express": "^4.17.11",
     "rxjs": "*"
   },
   "publishConfig": {
     "access": "public"
   },
   "gitHead": "9153d423f6d2416bbfb957f312379c2d9ad73547",
-  "dependencies": {
-    "@types/multer": "^1.4.7"
-  }
 }

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -44,5 +44,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "9153d423f6d2416bbfb957f312379c2d9ad73547"
+  "gitHead": "9153d423f6d2416bbfb957f312379c2d9ad73547",
+  "dependencies": {
+    "@types/multer": "^1.4.7"
+  }
 }

--- a/packages/nestjs/src/decorators.ts
+++ b/packages/nestjs/src/decorators.ts
@@ -50,11 +50,15 @@ export const Input = createParamDecorator((_data: void, ctx: ExecutionContext) =
     throw new Error('Attempting to use @Input() on an non-operation controller')
   }
 
-  // If file(s) are on the request push them to the request body
-  const file = request.file ? { file: request.file } : undefined
-  const files = request.files ? { files: request.files } : undefined
-  const body = operation.decodeBody({ ...request.body, ...file, ...files })
+  /*
+   * If multer has put a file at request.file push it onto the request body at * request.body.fieldName.
+   *
+   * Multiple files are not currently supported. Their shape is also irregular
+   * They can be in a singular array or an object keyed by fieldName. In either * scenario multiple files can map to the same fieldName
+   */
+  const fieldNameMappedFiles = request.file ? { [request.file.fieldname]: request.file } : undefined
 
+  const body = operation.decodeBody({ ...request.body, ...fieldNameMappedFiles })
   const params = operation.decodeParams(request.params)
   const query = operation.decodeQuery(request.query)
 

--- a/packages/nestjs/src/decorators.ts
+++ b/packages/nestjs/src/decorators.ts
@@ -50,7 +50,11 @@ export const Input = createParamDecorator((_data: void, ctx: ExecutionContext) =
     throw new Error('Attempting to use @Input() on an non-operation controller')
   }
 
-  const body = operation.decodeBody(request.body)
+  // If file(s) are on the request push them to the request body
+  const file = request.file ? {file: request.file} : undefined
+  const files = request.files ? {files: request.files} : undefined
+  const body = operation.decodeBody({...request.body, ...file, ...files})
+
   const params = operation.decodeParams(request.params)
   const query = operation.decodeQuery(request.query)
 

--- a/packages/nestjs/src/decorators.ts
+++ b/packages/nestjs/src/decorators.ts
@@ -51,9 +51,9 @@ export const Input = createParamDecorator((_data: void, ctx: ExecutionContext) =
   }
 
   // If file(s) are on the request push them to the request body
-  const file = request.file ? {file: request.file} : undefined
-  const files = request.files ? {files: request.files} : undefined
-  const body = operation.decodeBody({...request.body, ...file, ...files})
+  const file = request.file ? { file: request.file } : undefined
+  const files = request.files ? { files: request.files } : undefined
+  const body = operation.decodeBody({ ...request.body, ...file, ...files })
 
   const params = operation.decodeParams(request.params)
   const query = operation.decodeQuery(request.query)

--- a/packages/nestjs/src/decorators.ts
+++ b/packages/nestjs/src/decorators.ts
@@ -54,7 +54,8 @@ export const Input = createParamDecorator((_data: void, ctx: ExecutionContext) =
    * If multer has put a file at request.file push it onto the request body at * request.body.fieldName.
    *
    * Multiple files are not currently supported. Their shape is also irregular
-   * They can be in a singular array or an object keyed by fieldName. In either * scenario multiple files can map to the same fieldName
+   * They can be in a singular array or an object keyed by fieldName. In either
+   * scenario multiple files can map to the same fieldName
    */
   const fieldNameMappedFiles = request.file ? { [request.file.fieldname]: request.file } : undefined
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1468,6 +1468,16 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
+"@types/express@*":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
+  integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
 "@types/express@^4.17.11":
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.11.tgz#debe3caa6f8e5fcda96b47bd54e2f40c4ee59545"
@@ -1536,6 +1546,13 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
+
+"@types/multer@^1.4.7":
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/@types/multer/-/multer-1.4.7.tgz#89cf03547c28c7bbcc726f029e2a76a7232cc79e"
+  integrity sha512-/SNsDidUFCvqqcWDwxv2feww/yqhNeTRL5CVoL3jU4Goc4kKEL10T7Eye65ZqPNi4HRx8sAEX59pV1aEH7drNA==
+  dependencies:
+    "@types/express" "*"
 
 "@types/node@*":
   version "15.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1468,20 +1468,10 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express@*":
+"@types/express@*", "@types/express@^4.17.13":
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
   integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^4.17.18"
-    "@types/qs" "*"
-    "@types/serve-static" "*"
-
-"@types/express@^4.17.11":
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.11.tgz#debe3caa6f8e5fcda96b47bd54e2f40c4ee59545"
-  integrity sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "^4.17.18"


### PR DESCRIPTION
If multer (or some other interceptor/middleware) has put a `file` onto the request push them onto the request body for salus. 

Multer is included by default in nestjs so it makes sense to adopt this pattern for the nestjs package.