### PR TITLE
Allow parameterized content type

### DIFF
--- a/packages/http/src/operation.ts
+++ b/packages/http/src/operation.ts
@@ -1,9 +1,7 @@
 import { Any, Codec, OutputOf, TypeOf, Unknown, ValidationFailedError } from '@salus-js/codec'
 import { compile, PathFunction } from 'path-to-regexp'
 
-import { Methods } from './types'
-
-import { ContentType } from '.'
+import { ContentType, Methods } from './types'
 
 export interface OperationOptions<
   TParams extends Any = Unknown,

--- a/packages/http/src/operation.ts
+++ b/packages/http/src/operation.ts
@@ -3,6 +3,8 @@ import { compile, PathFunction } from 'path-to-regexp'
 
 import { Methods } from './types'
 
+import { ContentType } from '.'
+
 export interface OperationOptions<
   TParams extends Any = Unknown,
   TQuery extends Any = Unknown,
@@ -41,6 +43,10 @@ export interface OperationOptions<
    * Codec for path parameters
    */
   readonly body?: TBody
+  /**
+   * Content-Type for request body
+   */
+  readonly contentType?: ContentType
   /**
    * Codec for response payload
    */

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -21,3 +21,10 @@ export type BodyOf<T extends Operation> = T['_B']
  * Extracts the response type from an operation
  */
 export type ResponseOf<T extends Operation> = T['_R']
+
+export const contentTypes = [
+  'application/json',
+  'application-x-www-form-urlencoded',
+  'multipart/form-data'
+] as const
+export type ContentType = typeof contentTypes[number]

--- a/packages/openapi/src/builder.ts
+++ b/packages/openapi/src/builder.ts
@@ -3,7 +3,7 @@ import { Operation } from '@salus-js/http'
 
 import { SchemaConverter } from './converter'
 import {
-  createJsonRequestFactory,
+  createRequestFactory,
   createJsonResponseFactory,
   RequestFactory,
   ResponseFactory
@@ -42,7 +42,7 @@ export function toOpenApi(providedOptions: OpenAPIOptions): OpenAPIObject {
     tags = [],
     servers = [],
     security = [],
-    requestBodyFactory = createJsonRequestFactory(),
+    requestBodyFactory = createRequestFactory(),
     responseBodyFactory = createJsonResponseFactory(),
     additionalConverters,
     extraCodecs = [],

--- a/packages/openapi/src/factories.ts
+++ b/packages/openapi/src/factories.ts
@@ -19,21 +19,12 @@ export function createJsonResponseFactory(): ResponseFactory {
   })
 }
 
-export function createJsonRequestFactory(): RequestFactory {
-  return (operation, visitor) => ({
-    content: {
-      'application/json': {
-        schema: operation.options.body ? visitor.convert(operation.options.body) : {}
-      }
-    }
-  })
-}
-
-export function createFormRequestFactory(): RequestFactory {
+export function createRequestFactory(): RequestFactory {
   return (operation, visitor) => {
+    const contentType = operation.options.contentType ?? 'application/json'
     return {
       content: {
-        'application/x-www-form-urlencoded': {
+        [contentType]: {
           schema: operation.options.body ? visitor.convert(operation.options.body) : {}
         }
       }


### PR DESCRIPTION
http
- Allows `contentType` to be set on `Operation` (not required)
- I think this is fine as opposed to making it required

openapi
- Removed content type gated request factories 
- Instead it looks if the operation has an explicitly set content type, otherwise defaults to `application/json` which seems sensible given that a `requestBodyFactory` means that there is an actual requestBody and so there should be an accompanying `Content-Type`