### PR TITLE
Fixing mapped type issues with optionals

### DIFF
--- a/packages/codec/src/types/object.ts
+++ b/packages/codec/src/types/object.ts
@@ -1,7 +1,7 @@
 import { Context } from '../context'
 import { Any, OutputOf, TypeOf } from '../infer'
 import { isRecord, Optionalize, OptionalKeys } from '../utils'
-import { failure, ValidationError, Validation, failures, success } from '../validation'
+import { failure, failures, success, Validation, ValidationError } from '../validation'
 
 import { BaseCodec, CodecOptions, OptionalCodec } from './'
 

--- a/packages/codec/src/utils.ts
+++ b/packages/codec/src/utils.ts
@@ -3,10 +3,10 @@ import { OptionalCodec } from './types'
 export type OptionalKeys<T extends object> = {
   [K in keyof T]: T[K] extends OptionalCodec<any, any> ? K : never
 }[keyof T]
-export type Optionalize<T extends object, O extends keyof T> = {
-  [K in Exclude<keyof T, O>]: T[K]
-} &
-  { [K in O]?: T[K] }
+export type Optionalize<T extends object, O extends keyof T> = Pick<T, Exclude<keyof T, O>> &
+  {
+    [K in O]?: T[K]
+  }
 
 /**
  * Checks if an object is a generic record


### PR DESCRIPTION
The previous way we were handling making properties optional in TypeScript was resulting in the loss of mapped-type information. This meant when accessing a property on the type associated with a codec, you couldn't command+click on the property to get Intellisense information or take you to the declaration site. This small change on how we map optional types preserves that information and makes the dev experience just a little bit better.

Before (Notice the documentation for the property is missing):
![image](https://user-images.githubusercontent.com/1615780/135184548-7a99c197-b0fc-4b84-a867-3f965004588b.png)


After (notice the documentation for the property appears):
![image](https://user-images.githubusercontent.com/1615780/135184511-cb2e163a-9eea-4522-aa3c-28a18219ed64.png)
