### PR TITLE
Add trim to StringCodec

### DIFF
--- a/packages/codec/src/factories.ts
+++ b/packages/codec/src/factories.ts
@@ -26,6 +26,7 @@ import { UnionCodec } from './types/union'
 const boolean = new BooleanCodec()
 const number = new NumberCodec()
 const string = new StringCodec()
+const trimmedString = new StringCodec().trim()
 const nullType = new NullCodec()
 const unknown = new UnknownCodec()
 const undefinedType = new UndefinedCodec()
@@ -99,6 +100,7 @@ export {
   partial,
   record,
   string,
+  trimmedString,
   tuple,
   undefinedType as undefined,
   unknown,

--- a/packages/codec/src/factories.ts
+++ b/packages/codec/src/factories.ts
@@ -26,13 +26,17 @@ import { UnionCodec } from './types/union'
 const boolean = new BooleanCodec()
 const number = new NumberCodec()
 const string = new StringCodec()
-const trimmedString = new StringCodec().trim()
 const nullType = new NullCodec()
 const unknown = new UnknownCodec()
 const undefinedType = new UndefinedCodec()
 
 const isoDate = new IsoDateCodec()
 const isoDateTime = new IsoDateTimeCodec()
+
+/**
+ * Helpful factory for accepting string input
+ */
+const notBlankString = new StringCodec().trim().notEmpty()
 
 function enumFactory<T extends string>(value: Record<string, T> | ReadonlyArray<T>): EnumCodec<T> {
   return new EnumCodec(value)
@@ -94,13 +98,13 @@ export {
   lazy,
   literal,
   named,
+  notBlankString,
   nullType as null,
   number,
   object,
   partial,
   record,
   string,
-  trimmedString,
   tuple,
   undefinedType as undefined,
   unknown,

--- a/packages/codec/src/types/string.spec.ts
+++ b/packages/codec/src/types/string.spec.ts
@@ -29,21 +29,11 @@ describe('String Codec', () => {
     ),
     decodeSuccessExpectation('does not trim string by default', codec, ' hello ', ' hello '),
     decodeSuccessExpectation('trims on override', codec.trim(), ' hello ', 'hello'),
-    decodeSuccessExpectation('allows blank string by default', codec, ' ', ' '),
-    decodeSuccessExpectation('allows empty string on override', codec.allowEmpty(), '', ''),
-    decodeSuccessExpectation(
-      'allows blank string as empty string when trim and empty both overriden',
-      codec.trim().allowEmpty(),
-      ' ',
-      ''
-    ),
+    decodeSuccessExpectation('trims before refinements', codec.trim().maxLength(2), ' a ', 'a'),
     decodeFailureExpectation('not parse numbers', codec, 1, ['', 'must be a string']),
     decodeFailureExpectation('not parse booleans', codec, false, ['', 'must be a string']),
-    decodeFailureExpectation('does not allow empty string by default', codec, '', [
-      '',
-      'must not be empty'
-    ]),
-    decodeFailureExpectation('does not allow blank string when trimmed', codec.trim(), ' ', [
+    decodeSuccessExpectation('allow empty string by default', codec, '', ''),
+    decodeFailureExpectation('not empty default message', codec.notEmpty(), '', [
       '',
       'must not be empty'
     ]),

--- a/packages/codec/src/types/string.spec.ts
+++ b/packages/codec/src/types/string.spec.ts
@@ -27,20 +27,15 @@ describe('String Codec', () => {
       'hello',
       'hello'
     ),
-    decodeSuccessExpectation('trims string by default', codec, ' hello ', 'hello'),
-    decodeSuccessExpectation('does not trim on override', codec.doNotTrim(), ' hello ', ' hello '),
-    decodeSuccessExpectation(
-      'allows blank string trimmed as empty on override',
-      codec.allowEmpty(),
-      ' ',
-      ''
-    ),
+    decodeSuccessExpectation('does not trim string by default', codec, ' hello ', ' hello '),
+    decodeSuccessExpectation('trims on override', codec.trim(), ' hello ', 'hello'),
+    decodeSuccessExpectation('allows blank string by default', codec, ' ', ' '),
     decodeSuccessExpectation('allows empty string on override', codec.allowEmpty(), '', ''),
     decodeSuccessExpectation(
-      'allows blank string when trim and empty both overriden',
-      codec.doNotTrim().allowEmpty(),
+      'allows blank string as empty string when trim and empty both overriden',
+      codec.trim().allowEmpty(),
       ' ',
-      ' '
+      ''
     ),
     decodeFailureExpectation('not parse numbers', codec, 1, ['', 'must be a string']),
     decodeFailureExpectation('not parse booleans', codec, false, ['', 'must be a string']),
@@ -48,7 +43,7 @@ describe('String Codec', () => {
       '',
       'must not be empty'
     ]),
-    decodeFailureExpectation('does not allow blank string by default', codec, ' ', [
+    decodeFailureExpectation('does not allow blank string when trimmed', codec.trim(), ' ', [
       '',
       'must not be empty'
     ]),

--- a/packages/codec/src/types/string.spec.ts
+++ b/packages/codec/src/types/string.spec.ts
@@ -27,11 +27,34 @@ describe('String Codec', () => {
       'hello',
       'hello'
     ),
+    decodeSuccessExpectation('trims string by default', codec, ' hello ', 'hello'),
+    decodeSuccessExpectation('does not trim on override', codec.doNotTrim(), ' hello ', ' hello '),
+    decodeSuccessExpectation(
+      'allows blank string trimmed as empty on override',
+      codec.allowEmpty(),
+      ' ',
+      ''
+    ),
+    decodeSuccessExpectation('allows empty string on override', codec.allowEmpty(), '', ''),
+    decodeSuccessExpectation(
+      'allows blank string on double override',
+      codec.doNotTrim().allowEmpty(),
+      ' ',
+      ' '
+    ),
     decodeFailureExpectation('not parse numbers', codec, 1, ['', 'must be a string']),
     decodeFailureExpectation('not parse booleans', codec, false, ['', 'must be a string']),
-    decodeFailureExpectation('respect minLength', codec.minLength(1), '', [
+    decodeFailureExpectation('does not allow empty string by default', codec, '', [
       '',
-      'must be at least 1 characters'
+      'must not be empty'
+    ]),
+    decodeFailureExpectation('does not allow blank string by default', codec, ' ', [
+      '',
+      'must not be empty'
+    ]),
+    decodeFailureExpectation('respect minLength', codec.minLength(2), 'a', [
+      '',
+      'must be at least 2 characters'
     ]),
     decodeFailureExpectation('respect maxLength', codec.maxLength(1), 'asdf', [
       '',

--- a/packages/codec/src/types/string.spec.ts
+++ b/packages/codec/src/types/string.spec.ts
@@ -37,7 +37,7 @@ describe('String Codec', () => {
     ),
     decodeSuccessExpectation('allows empty string on override', codec.allowEmpty(), '', ''),
     decodeSuccessExpectation(
-      'allows blank string on double override',
+      'allows blank string when trim and empty both overriden',
       codec.doNotTrim().allowEmpty(),
       ' ',
       ' '

--- a/packages/codec/src/types/string.ts
+++ b/packages/codec/src/types/string.ts
@@ -7,16 +7,16 @@ export class StringCodec extends BaseCodec<string> {
   readonly _tag = 'StringCodec' as const
 
   private readonly trimString: boolean
-  public readonly notEmpty: boolean
+  public readonly rejectEmpty: boolean
 
   constructor(
     trimString: boolean = false,
-    notEmpty: boolean = true,
+    rejectEmpty: boolean = true,
     options: CodecOptions<string> = {}
   ) {
     super(options)
     this.trimString = trimString
-    this.notEmpty = notEmpty
+    this.rejectEmpty = rejectEmpty
   }
 
   protected doIs(value: unknown): value is string {
@@ -34,7 +34,7 @@ export class StringCodec extends BaseCodec<string> {
 
     const result = this.trimString ? value.trim() : value
 
-    if (this.notEmpty && result === '') {
+    if (this.rejectEmpty && result === '') {
       return failure(context, value, 'must not be empty')
     }
 
@@ -42,7 +42,7 @@ export class StringCodec extends BaseCodec<string> {
   }
 
   protected with(options: CodecOptions<string>): BaseCodec<string> {
-    return new StringCodec(this.trimString, this.notEmpty, options)
+    return new StringCodec(this.trimString, this.rejectEmpty, options)
   }
 
   public minLength(length: number, message?: string): StringCodec {
@@ -74,6 +74,6 @@ export class StringCodec extends BaseCodec<string> {
   }
 
   public trim(): StringCodec {
-    return new StringCodec(true, this.notEmpty, this.options)
+    return new StringCodec(true, this.rejectEmpty, this.options)
   }
 }

--- a/packages/codec/src/types/string.ts
+++ b/packages/codec/src/types/string.ts
@@ -7,16 +7,10 @@ export class StringCodec extends BaseCodec<string> {
   readonly _tag = 'StringCodec' as const
 
   private readonly trimString: boolean
-  public readonly rejectEmpty: boolean
 
-  constructor(
-    trimString: boolean = false,
-    rejectEmpty: boolean = true,
-    options: CodecOptions<string> = {}
-  ) {
+  constructor(trimString: boolean = false, options: CodecOptions<string> = {}) {
     super(options)
     this.trimString = trimString
-    this.rejectEmpty = rejectEmpty
   }
 
   protected doIs(value: unknown): value is string {
@@ -32,17 +26,15 @@ export class StringCodec extends BaseCodec<string> {
       return failure(context, value, 'must be a string')
     }
 
-    const result = this.trimString ? value.trim() : value
-
-    if (this.rejectEmpty && result === '') {
-      return failure(context, value, 'must not be empty')
-    }
-
-    return success(result)
+    return success(this.trimString ? value.trim() : value)
   }
 
   protected with(options: CodecOptions<string>): BaseCodec<string> {
-    return new StringCodec(this.trimString, this.rejectEmpty, options)
+    return new StringCodec(this.trimString, options)
+  }
+
+  public notEmpty(message?: string): StringCodec {
+    return this.minLength(1, message ?? 'must not be empty')
   }
 
   public minLength(length: number, message?: string): StringCodec {
@@ -69,11 +61,7 @@ export class StringCodec extends BaseCodec<string> {
     })
   }
 
-  public allowEmpty(): StringCodec {
-    return new StringCodec(this.trimString, false, this.options)
-  }
-
   public trim(): StringCodec {
-    return new StringCodec(true, this.rejectEmpty, this.options)
+    return new StringCodec(true, this.options)
   }
 }

--- a/packages/codec/src/types/string.ts
+++ b/packages/codec/src/types/string.ts
@@ -7,10 +7,10 @@ export class StringCodec extends BaseCodec<string> {
   readonly _tag = 'StringCodec' as const
 
   private readonly trimString: boolean
-  private readonly notEmpty: boolean
+  public readonly notEmpty: boolean
 
   constructor(
-    trimString: boolean = true,
+    trimString: boolean = false,
     notEmpty: boolean = true,
     options: CodecOptions<string> = {}
   ) {
@@ -73,7 +73,7 @@ export class StringCodec extends BaseCodec<string> {
     return new StringCodec(this.trimString, false, this.options)
   }
 
-  public doNotTrim(): StringCodec {
-    return new StringCodec(false, this.notEmpty, this.options)
+  public trim(): StringCodec {
+    return new StringCodec(true, this.notEmpty, this.options)
   }
 }

--- a/packages/openapi/src/converters/string.ts
+++ b/packages/openapi/src/converters/string.ts
@@ -5,7 +5,7 @@ import { mapRefinement } from './utils'
 
 export const StringConverter = SimpleConverter.for(StringCodec, (codec) => ({
   type: 'string',
-  ...(codec.notEmpty ? { minLength: 1 } : {}),
+  ...(codec.rejectEmpty ? { minLength: 1 } : {}),
   ...mapRefinement<number>(codec, 'minLength', (minLength) => ({
     minLength
   })),

--- a/packages/openapi/src/converters/string.ts
+++ b/packages/openapi/src/converters/string.ts
@@ -5,6 +5,7 @@ import { mapRefinement } from './utils'
 
 export const StringConverter = SimpleConverter.for(StringCodec, (codec) => ({
   type: 'string',
+  ...(codec.notEmpty ? { minLength: 1 } : {}),
   ...mapRefinement<number>(codec, 'minLength', (minLength) => ({
     minLength
   })),

--- a/packages/openapi/src/converters/string.ts
+++ b/packages/openapi/src/converters/string.ts
@@ -5,7 +5,6 @@ import { mapRefinement } from './utils'
 
 export const StringConverter = SimpleConverter.for(StringCodec, (codec) => ({
   type: 'string',
-  ...(codec.rejectEmpty ? { minLength: 1 } : {}),
   ...mapRefinement<number>(codec, 'minLength', (minLength) => ({
     minLength
   })),


### PR DESCRIPTION
- Adds the option to `trimString` propertt to `StringCodec`
  - trim is false by default
  - `trim()` exists as override functions
- Exports a `notBlankString` factory as a useful helper for input codecs
