### PR TITLE
Remove notBlankString

### DIFF
--- a/packages/codec/src/factories.ts
+++ b/packages/codec/src/factories.ts
@@ -33,11 +33,6 @@ const undefinedType = new UndefinedCodec()
 const isoDate = new IsoDateCodec()
 const isoDateTime = new IsoDateTimeCodec()
 
-/**
- * Helpful factory for accepting string input
- */
-const notBlankString = new StringCodec().trim().notEmpty()
-
 function enumFactory<T extends string>(value: Record<string, T> | ReadonlyArray<T>): EnumCodec<T> {
   return new EnumCodec(value)
 }
@@ -98,7 +93,6 @@ export {
   lazy,
   literal,
   named,
-  notBlankString,
   nullType as null,
   number,
   object,


### PR DESCRIPTION
`notBlankString` is not an appropriate name as the codec also trims otherwise valid input, which may be surprising to someone only expecting that it would validate against blanks. It was intended as a factory helper for people accepting string inputs that they wanted to trim and not accept empty strings. Consumers can still create easily create that codec in their own project. If demand arises this can be later introduced as an export by Salus.