### PR TITLE
[LazyCodec] Add optional(), nullable(), document()

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.14.0",
+  "version": "0.14.1",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/codec/package-lock.json
+++ b/packages/codec/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@salus-js/codec",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 1
 }

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salus-js/codec",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/codec/src/types/lazy.spec.ts
+++ b/packages/codec/src/types/lazy.spec.ts
@@ -13,4 +13,17 @@ describe('Lazy Codec', () => {
       'must be a string'
     ])
   ])
+
+  const optionalCodec = new LazyCodec(() => new StringCodec())
+    .optional()
+    .document({ description: 'Blah blah' })
+
+  executeDecodeTests([
+    decodeSuccessExpectation('parse simple string', optionalCodec, 'one', 'one'),
+    decodeSuccessExpectation('parse undefined', optionalCodec, undefined, undefined),
+    decodeFailureExpectation('reject invalid values for inner codec', optionalCodec, 1, [
+      '',
+      'must be a string'
+    ])
+  ])
 })

--- a/packages/codec/src/types/lazy.ts
+++ b/packages/codec/src/types/lazy.ts
@@ -2,12 +2,16 @@ import { Codec } from '../codec'
 import { Context } from '../context'
 import { Validation } from '../validation'
 
+import { CodecOptions } from './base'
+import { NullableCodec } from './nullable'
+import { OptionalCodec } from './optional'
+
 export class LazyCodec<A, O> extends Codec<A, O> {
   readonly _tag = 'LazyCodec' as const
 
   private internalCache: Codec<A, O> | null = null
 
-  constructor(public readonly resolver: () => Codec<A, O>) {
+  constructor(public readonly resolver: () => Codec<A, O>, readonly options?: CodecOptions<A>) {
     super()
   }
 
@@ -29,5 +33,26 @@ export class LazyCodec<A, O> extends Codec<A, O> {
 
   public decode(value: unknown, context: Context = Context.create(this)): Validation<A> {
     return this.codec.decode(value, context.replace(this.codec))
+  }
+
+  public optional(): OptionalCodec<A, O> {
+    return new OptionalCodec(this)
+  }
+
+  public nullable(): NullableCodec<A, O> {
+    return new NullableCodec(this)
+  }
+
+  public document(
+    options: Pick<CodecOptions<A>, 'title' | 'description' | 'example' | 'extensions'>
+  ): this {
+    return this.with({
+      ...this.options,
+      ...options
+    }) as this
+  }
+
+  protected with(options: CodecOptions<A>): LazyCodec<A, O> {
+    return new LazyCodec(this.resolver, options)
   }
 }

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salus-js/http-client",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -37,8 +37,8 @@
   },
   "gitHead": "9153d423f6d2416bbfb957f312379c2d9ad73547",
   "devDependencies": {
-    "@salus-js/codec": "^0.14.0",
-    "@salus-js/http": "^0.14.0",
+    "@salus-js/codec": "^0.14.1",
+    "@salus-js/http": "^0.14.1",
     "axios": "^0.21.1"
   },
   "peerDependencies": {

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salus-js/http",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -32,7 +32,7 @@
     "path-to-regexp": "^6.2.0"
   },
   "devDependencies": {
-    "@salus-js/codec": "^0.14.0"
+    "@salus-js/codec": "^0.14.1"
   },
   "peerDependencies": {
     "@salus-js/codec": "*"

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salus-js/nestjs",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@nestjs/common": "^8.4.2",
     "@nestjs/core": "^8.4.2",
-    "@salus-js/codec": "^0.14.0",
-    "@salus-js/http": "^0.14.0",
-    "@salus-js/openapi": "^0.14.0",
+    "@salus-js/codec": "^0.14.1",
+    "@salus-js/http": "^0.14.1",
+    "@salus-js/openapi": "^0.14.1",
     "@types/express": "^4.17.13",
     "express": "^4",
     "reflect-metadata": "^0.1.13",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salus-js/openapi",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -18,8 +18,8 @@
     "README.md"
   ],
   "devDependencies": {
-    "@salus-js/codec": "^0.14.0",
-    "@salus-js/http": "^0.14.0"
+    "@salus-js/codec": "^0.14.1",
+    "@salus-js/http": "^0.14.1"
   },
   "peerDependencies": {
     "@salus-js/codec": "*",


### PR DESCRIPTION
LazyCodec doesn't extend BaseCodec, so it has been missing the common helper methods that let us chain .optional() or .document(). There's nothing stopping us from defining those helpers on LazyCodec.

- Implement LazyCodec.with()
- Copy-paste optional(), nullable, and document() from BaseCodec
