### PR TITLE
[http] Allow request bodies in delete requests

### DIFF
--- a/packages/http/src/handlers.ts
+++ b/packages/http/src/handlers.ts
@@ -48,5 +48,5 @@ export const http = {
   put: createOperationHandler('put', true),
   post: createOperationHandler('post', true),
   patch: createOperationHandler('patch', false),
-  delete: createOperationHandler('delete', false)
+  delete: createOperationHandler('delete', true)
 }


### PR DESCRIPTION
Some APIs [0] do use bodies with delete requests. We can allow that.

[0] https://docs.cronofy.com/developers/api/events/bulk-delete-events/
